### PR TITLE
お悩みカード一覧を表示する際に読み込みアニメーションが終わらないバグを修正

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ void main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   // 位置情報確認ダイアログを表示
+  // アプリ起動時の端末の位置情報も保持しておく
   FunctionUtils.instance.determinePosition();
 
   runApp(ProviderScope(

--- a/lib/presentation/components/onayami_card_disp_view_model.dart
+++ b/lib/presentation/components/onayami_card_disp_view_model.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:onayamijika/domain/interfaces/i_account_repository.dart';
 import 'package:onayamijika/domain/interfaces/i_solution_seal_repository.dart';
 import 'package:onayamijika/domain/models/%20solution_seal_view.dart';
@@ -32,9 +31,22 @@ class OnayamiCardDispViewModel {
 
   /// 表面の表示用オブジェクトを作成する
   Future<OnayamiCardView> createOnayamiCardView() async {
+    // カード作成者を取得
     final cardAccount = await accountRepository.fetchAccountFromUid(
         uid: card.cardDocument.createAccountUid);
-    final distance = await calcDistance();
+    final utils = FunctionUtils.instance;
+
+    // 距離計算
+    // 端末に位置情報を許可していない場合は、位置情報が取得できていないのでその場合は0.0を表示するようにしておく
+    double distance = 0.0;
+    if (utils.currentPostion != null) {
+      distance = utils.distanceBetween(
+          latitude1: utils.currentPostion!.latitude,
+          longitude1: utils.currentPostion!.longitude,
+          latitude2: card.cardDocument.latitude,
+          longitude2: card.cardDocument.longitude);
+    }
+
     return OnayamiCardView(
         accountImageUrl: cardAccount.accountImageUrl,
         accountName: cardAccount.accountName,
@@ -50,15 +62,5 @@ class OnayamiCardDispViewModel {
     final seals =
         await sealRepository.fetchSealsFromCardId(cardId: card.cardId);
     return SolutionSealView(seals: seals);
-  }
-
-  /// 距離を計算する
-  Future<double> calcDistance() async {
-    final myPosition = await Geolocator.getCurrentPosition();
-    return FunctionUtils.instance.distanceBetween(
-        latitude1: myPosition.latitude,
-        longitude1: myPosition.longitude,
-        latitude2: card.cardDocument.latitude,
-        longitude2: card.cardDocument.longitude);
   }
 }

--- a/lib/presentation/views/onayamijika/onayami_cards_page.dart
+++ b/lib/presentation/views/onayamijika/onayami_cards_page.dart
@@ -34,6 +34,7 @@ class OnayamiCardsPage extends ConsumerWidget {
                       itemBuilder: (context, index) {
                         return OnayamiCardForDisp(card: data[index]);
                       },
+                      loop: false,
                       itemCount: data.length,
                       viewportFraction: 0.8,
                       scale: 0.9,

--- a/lib/utils/function_utils.dart
+++ b/lib/utils/function_utils.dart
@@ -16,8 +16,11 @@ class FunctionUtils {
   FunctionUtils._();
   static final instance = FunctionUtils._();
 
+  /// 端末の現在地（許可されていない場合は位置情報を取得できないのでnullを入れる）
+  late Position? currentPostion;
+
   /// ランダムで生成するカード色のリスト
-  final List<Color> cardColors = [
+  final List<Color> _cardColors = [
     AppColors.skyGreen,
     AppColors.lightPink,
     AppColors.salmonPink,
@@ -30,7 +33,7 @@ class FunctionUtils {
   /// お悩みカードに使用する色をランダムで生成する
   String getRandomColorForOnayamiCard() {
     final rand = math.Random();
-    return ColorToHex(cardColors[rand.nextInt(7)]).value.toString();
+    return ColorToHex(_cardColors[rand.nextInt(7)]).value.toString();
   }
 
   /// ウィジェットを画像化する
@@ -103,6 +106,7 @@ class FunctionUtils {
 
     // ここまでたどり着くと、位置情報に対しての権限が許可されているということなので
     // デバイスの位置情報を返す。
-    return await Geolocator.getCurrentPosition();
+    currentPostion = await Geolocator.getCurrentPosition();
+    return currentPostion!;
   }
 }


### PR DESCRIPTION
#9 
原因：カードを作成するたびに毎回、自端末の位置情報を取り直していたため
対策：アプリ起動時に一回だけ自端末の位置情報を取得してカード表示時にそれを使い回すようにした